### PR TITLE
Added troubleshooting step for multiple Azure subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Run **az account get-access-token** to see if Azure CLI shows a token for you. I
 2. AzureServiceTokenProvider cannot find the path for Azure CLI.
 AzureServiceTokenProvider finds Azure CLI at its default install locations. If it cannot find Azure CLI, please set environment variable **AzureCLIPath** to the Azure CLI installation folder. AzureServiceTokenProvider will add the environment variable to the Path environment variable.
 
+3. Unauthorized access response when trying to access/set keys when you have multiple Azure subscriptions. Make sure you set the subscription with Key Vault to be the default using the command: **az account set --subscription <subscription-id>**. If no output is seen, then it succeeded. Verify the right account is no the default using **az account list**.
+
 ### Common issues when deployed to Azure App Service:
 
 1. MSI is not setup on the App Service. 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Run **az account get-access-token** to see if Azure CLI shows a token for you. I
 2. AzureServiceTokenProvider cannot find the path for Azure CLI.
 AzureServiceTokenProvider finds Azure CLI at its default install locations. If it cannot find Azure CLI, please set environment variable **AzureCLIPath** to the Azure CLI installation folder. AzureServiceTokenProvider will add the environment variable to the Path environment variable.
 
-3. Unauthorized access response when trying to access/set keys when you have multiple Azure subscriptions. Make sure you set the subscription with Key Vault to be the default using the command: **az account set --subscription <subscription-id>**. If no output is seen, then it succeeded. Verify the right account is no the default using **az account list**.
+3. Unauthorized access response when trying to access/set keys when you have multiple Azure subscriptions. Make sure you set the subscription with Key Vault to be the default using the command: **az account set --subscription <subscription-id>**. If no output is seen, then it succeeded. Verify the right account is now the default using **az account list**.
 
 ### Common issues when deployed to Azure App Service:
 


### PR DESCRIPTION
## Purpose
* Adds documentation about how to use authentication locally when running with multiple Azure accounts.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  n/a

## What to Check
* Section "Common issues when deployed to Azure App Service" Subsection 3 makes sense.

## Other Information
This was added because when I was following the tutorial nothing worked due to having two different azure accounts. I then found that I needed to set the default subscription to the one containing the Key Vault for the authentication to work correctly. I figured it would be good for others to see when troubleshooting.