### PR TITLE
added fix to get keyvault secret value instead of keyvault secret obj…

### DIFF
--- a/WebAppKeyVault/WebAppKeyVault/Controllers/HomeController.cs
+++ b/WebAppKeyVault/WebAppKeyVault/Controllers/HomeController.cs
@@ -16,7 +16,7 @@ namespace WebAppKeyVault.Controllers
                 string uri = Environment.GetEnvironmentVariable("KEY_VAULT_URI");
                 SecretClient client = new SecretClient(new Uri(uri), new DefaultAzureCredential());
 
-                Response<KeyVaultSecret> secret = await client.GetSecretAsync("secret");
+                var secret = (await client.GetSecretAsync("secret")).Value;
 
                 ViewBag.Secret = $"Secret: {secret.Value}";
             }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR fixes the issue where Keyvault Secret object gets returned instead of Keyvault Secret value.

![image](https://user-images.githubusercontent.com/3292092/101949012-f976bc80-3bc0-11eb-9f6c-9ba343888ab5.png)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
Code change in HomeController.cs file. 

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Follow Readme.md instruction to create Azure resources and adding keyvault url environment variable
* Run this code and it should return result something similar to this: **Secret: [your secret value you entered in keyvault]** instead of **Secret: Azure.Security.KeyVault.Secrets.KeyVaultSecret**


```
git clone [repo-address]
cd WebAppKeyVault
git checkout bugfix/get-kv-secret-value
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Create Azure Resources from the instruction provided in Readme.md
Set environment variable in local computer
Run code in Visual Studio
Check the value of **secret** variable in HomeController.cs in Index method.
```

## What to Check
Verify that the following are valid
* The value of **Secret** should match with secret value that is entered keyvault.
